### PR TITLE
FIX: Add a Github Action to build and package fastfetch for Debian. (#127)

### DIFF
--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -1,0 +1,47 @@
+name: CMake
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    # Install dependencies, so that CMake enables all modules
+    - name: install packages
+      run: sudo apt-get update && sudo apt-get install -y libpci-dev libvulkan-dev libwayland-dev libxrandr-dev libxcb-randr0-dev libdconf-dev libxfconf-0-dev librpm-dev libzstd-dev
+   
+    # Kick off the debian packaging
+    - name: Create deb package
+      working-directory: ${{github.workspace}}/packaging/deb
+      run: sh ./create-deb-pkg.sh
+      
+      
+    # Create a release draft with the fastfetch.deb file
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Debian package for ${{ github.sha }}
+        draft: true
+        prerelease: false
+        
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ${{github.workspace}}/packaging/deb/fastfetch.deb
+        asset_name: fastfetch.deb
+        asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/compile-and-run-ff.yml
+++ b/.github/workflows/compile-and-run-ff.yml
@@ -1,0 +1,38 @@
+name: CMake
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    # Install dependencies, so that CMake enables all modules
+    - name: install packages
+      run: sudo apt-get update && sudo apt-get install -y libpci-dev libvulkan-dev libwayland-dev libxrandr-dev libxcb-randr0-dev libdconf-dev libxfconf-0-dev librpm-dev libzstd-dev
+    
+    # Just build fastfetch normally. This is to check for compilation/program errors.
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    
+    - name: Run fastfetch
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ./fastfetch
+      


### PR DESCRIPTION
You accidentally merged a broken action, as the "on:" key was not optional. This is a fix for that.